### PR TITLE
Edited JoeBlogs/wrappers/MetaWeblogWrapper.cs via GitHub

### DIFF
--- a/JoeBlogs/wrappers/MetaWeblogWrapper.cs
+++ b/JoeBlogs/wrappers/MetaWeblogWrapper.cs
@@ -37,7 +37,7 @@ namespace JoeBlogs
         public virtual int NewPost(Post post, bool publish)
         {
             var content = Map.From.Post(post);
-            return Convert.ToInt16(_wrapper.NewPost(this.BlogID, Username, Password, content, publish));
+            return Convert.ToInt32(_wrapper.NewPost(this.BlogID, Username, Password, content, publish));
         }
 
         public virtual bool EditPost(int postID, Post content, bool publish)


### PR DESCRIPTION
Changed NewPost(...) - Now it converts return value to int32, instead of Int16, because return id can be larger than 32767. 
